### PR TITLE
feat: add support for Dgraph connection strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
+## [XX.X.X] - 2025-XX-XX
+
+**Added**
+
+- add support for Dgraph connection strings (#XXX)
+
 ## [24.1.1] - 2024-12-13
 
 **Added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 **Added**
 
-- add support for Dgraph connection strings (#XXX)
+- add support for Dgraph connection strings (#268)
 
 ## [24.1.1] - 2024-12-13
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,47 @@ client and use it to mutate or query dgraph. For the async client, more details 
 
 ### Creating a Client
 
+#### Using a Connection String
+
+This library supports connecting to a Dgraph cluster using connection strings. Dgraph connections
+strings take the form `dgraph://{username:password@}host:port?args`.
+
+`username` and `password` are optional. If username is provided, a password must also be present. If
+supplied, these credentials are used to log into a Dgraph cluster through the ACL mechanism.
+
+Valid connection string args:
+
+| Arg         | Value                           | Description                                                                                                                                                   |
+| ----------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| apikey      | \<key\>                         | a Dgraph Cloud API Key                                                                                                                                        |
+| bearertoken | \<token\>                       | an access token                                                                                                                                               |
+| sslmode     | disable \| require \| verify-ca | TLS option, the default is `disable`. If `verify-ca` is set, the TLS certificate configured in the Dgraph cluster must be from a valid certificate authority. |
+
+Note that using `sslmode=require` disables certificate validation and significantly reduces the
+security of TLS. This mode should only be used in non-production (e.g., testing or development)
+environments.
+
+Some example connection strings:
+
+| Value                                                                                                        | Explanation                                                                         |
+| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| dgraph://localhost:9080                                                                                      | Connect to localhost, no ACL, no TLS                                                |
+| dgraph://sally:supersecret@dg.example.com:443?sslmode=verify-ca                                              | Connect to remote server, use ACL and require TLS and a valid certificate from a CA |
+| dgraph://foo-bar.grpc.us-west-2.aws.cloud.dgraph.io:443?sslmode=verify-ca&apikey=\<your-api-connection-key\> | Connect to a Dgraph Cloud cluster                                                   |
+| dgraph://foo-bar.grpc.hypermode.com?sslmode=verify-ca&bearertoken=\<some access token\>                      | Connect to a Dgraph cluster protected by a secure gateway                           |
+
+Using the `DgraphClient.openConnection` function with a connection string:
+
+```java
+// open a connection to an ACL-enabled, non-TLS cluster and login as groot
+DgraphClient client = DgraphClient.openConnection("dgraph://groot:password@localhost:8090");
+
+// some time later...
+client.shutdown();
+```
+
+#### Using Managed Channels
+
 The following code snippet shows how to create a synchronous client using three connections.
 
 ```java
@@ -200,6 +241,9 @@ them as follows :
 DgraphStub stub = DgraphClient.clientStubFromCloudEndpoint("https://your-instance.cloud.dgraph.io/graphql", "your-api-key");
 DgraphClient dgraphClient = new DgraphClient(stub);
 ```
+
+Note the `DgraphClient.openConnection` method can be used if you have a Dgraph connection string
+(see above).
 
 ### Creating a Secure Client using TLS
 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ Some example connection strings:
 | dgraph://foo-bar.grpc.us-west-2.aws.cloud.dgraph.io:443?sslmode=verify-ca&apikey=\<your-api-connection-key\> | Connect to a Dgraph Cloud cluster                                                   |
 | dgraph://foo-bar.grpc.hypermode.com?sslmode=verify-ca&bearertoken=\<some access token\>                      | Connect to a Dgraph cluster protected by a secure gateway                           |
 
-Using the `DgraphClient.openConnection` function with a connection string:
+Using the `DgraphClient.open` function with a connection string:
 
 ```java
 // open a connection to an ACL-enabled, non-TLS cluster and login as groot
-DgraphClient client = DgraphClient.openConnection("dgraph://groot:password@localhost:8090");
+DgraphClient client = DgraphClient.open("dgraph://groot:password@localhost:8090");
 
 // some time later...
 client.shutdown();
@@ -242,8 +242,7 @@ DgraphStub stub = DgraphClient.clientStubFromCloudEndpoint("https://your-instanc
 DgraphClient dgraphClient = new DgraphClient(stub);
 ```
 
-Note the `DgraphClient.openConnection` method can be used if you have a Dgraph connection string
-(see above).
+Note the `DgraphClient.open` method can be used if you have a Dgraph connection string (see above).
 
 ### Creating a Secure Client using TLS
 

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -97,12 +97,12 @@ public class DgraphClient {
     }
 
     /**
-     * Sets an API key for authorization.
+     * Sets a Dgraph API key for authorization.
      *
      * @param apiKey The API key to use for authorization.
      * @return This ClientOptions instance for chaining.
      */
-    public ClientOptions withApiKey(String apiKey) {
+    public ClientOptions withDgraphApiKey(String apiKey) {
       this.authorizationToken = apiKey;
       return this;
     }
@@ -325,7 +325,7 @@ public class DgraphClient {
     }
 
     if (params.containsKey("apikey")) {
-      options.withApiKey(params.get("apikey"));
+      options.withDgraphApiKey(params.get("apikey"));
     } else if (params.containsKey("bearertoken")) {
       options.withBearerToken(params.get("bearertoken"));
     }

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -154,7 +154,6 @@ public class DgraphClient {
         throw new IllegalArgumentException("Invalid sslmode: " + sslmode);
       }
     } else {
-      // Default to usePlaintext if not specified
       channelBuilder.usePlaintext();
     }
 

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -66,7 +66,7 @@ public class DgraphClient {
    * @throws MalformedURLException If the connection string cannot be parsed as a URL
    * @throws SSLException If there's an error configuring the SSL context for sslmode=require
    */
-  public static DgraphClient openConnection(String connectionString)
+  public static DgraphClient open(String connectionString)
       throws IllegalArgumentException, MalformedURLException, SSLException {
     if (connectionString == null || connectionString.isEmpty()) {
       throw new IllegalArgumentException("Connection string cannot be null or empty");

--- a/src/test/java/io/dgraph/DgraphConnTest.java
+++ b/src/test/java/io/dgraph/DgraphConnTest.java
@@ -1,0 +1,208 @@
+/*
+ * SPDX-FileCopyrightText: © Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.dgraph;
+
+import static org.testng.Assert.*;
+import static org.testng.Assert.fail;
+
+import io.dgraph.DgraphProto.Response;
+import org.testng.annotations.Test;
+
+/**
+ * @author Matthew McNeely
+ */
+public class DgraphConnTest {
+
+  // Define a constant for the expected JSON response
+  private static final String EXPECTED_UID_JSON = "{\"me\":[{\"uid\":\"0x1\"}]}";
+
+  /**
+   * Tests the Dgraph connection using the openConnection method with ACL credentials.
+   * This test connects to a local Dgraph server with authentication.
+   */
+  @Test
+  public void testOpenConnectionWithACL() {
+    try {
+      String conn = "dgraph://groot:password@localhost:9180";
+      DgraphClient client = DgraphClient.openConnection(conn);
+      assertNotNull(client);
+      
+      String query = "{ me(func: uid(1)) { uid }}";
+      Response response = client.newTransaction().query(query);
+      assertNotNull(response);
+      
+      assertEquals(response.getJson().toStringUtf8(), EXPECTED_UID_JSON);
+      
+      client.shutdown();
+    } catch (Exception e) {
+      fail("Failed to connect with ACL: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that connecting without ACL credentials fails with an appropriate exception.
+   * The test expects an exception when trying to connect to a Dgraph server with ACL enabled
+   * but without providing credentials.
+   */
+  @Test
+  public void testOpenConnectionWithoutACL() {
+    try {
+      // Try to connect without providing credentials
+      String conn = "dgraph://localhost:9180";
+      DgraphClient client = DgraphClient.openConnection(conn);
+      
+      // Try a query to trigger the authentication error
+      String query = "{ me(func: uid(1)) { uid }}";
+      client.newTransaction().query(query);
+      
+      // If we reach here, the test has failed
+      fail("Expected an exception when connecting without ACL credentials");
+    } catch (Exception e) {
+      // The exception should contain authentication/permission related message
+      // Look for exceptions like "unauthenticated", "permission denied", etc.
+      boolean hasAuthError = false;
+      Throwable cause = e;
+      while (cause != null) {
+        String message = cause.getMessage() != null ? cause.getMessage().toLowerCase() : "";
+        if (message.contains("unauthenticated") || 
+            message.contains("permission denied") || 
+            message.contains("unauthorized") ||
+            message.contains("access") ||
+            message.contains("auth")) {
+          hasAuthError = true;
+          break;
+        }
+        cause = cause.getCause();
+      }
+      
+      assertTrue(hasAuthError, "Exception should be related to authentication or permissions: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that an appropriate exception is thrown when the connection string is missing a required port.
+   */
+  @Test
+  public void testMissingPortException() {
+    try {
+      // Missing port in connection string should throw IllegalArgumentException
+      String conn = "dgraph://localhost";
+      DgraphClient.openConnection(conn);
+      fail("Should have thrown IllegalArgumentException for missing port");
+    } catch (IllegalArgumentException e) {
+      // Expected exception
+      assertTrue(e.getMessage().contains("port required"));
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getClass().getName() + ": " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that an appropriate exception is thrown when the connection string has an invalid schema.
+   */
+  @Test
+  public void testInvalidSchemaException() {
+    try {
+      // Invalid schema should throw IllegalArgumentException
+      String conn = "http://localhost:9180";
+      DgraphClient.openConnection(conn);
+      fail("Should have thrown IllegalArgumentException for invalid schema");
+    } catch (IllegalArgumentException e) {
+      // Expected exception
+      assertTrue(e.getMessage().contains("scheme must be 'dgraph'"));
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getClass().getName() + ": " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that an appropriate exception is thrown when the connection string includes a username but no password.
+   */
+  @Test
+  public void testMissingPasswordException() {
+    try {
+      // Username without password should throw IllegalArgumentException
+      String conn = "dgraph://groot@localhost:9180";
+      DgraphClient.openConnection(conn);
+      fail("Should have thrown IllegalArgumentException for missing password");
+    } catch (IllegalArgumentException e) {
+      // Expected exception
+      assertTrue(e.getMessage().contains("password required when username is provided"));
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getClass().getName() + ": " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that an appropriate exception is thrown when the connection string has an invalid sslmode.
+   */
+  @Test
+  public void testInvalidSSLModeException() {
+    try {
+      // Invalid sslmode should throw IllegalArgumentException
+      String conn = "dgraph://localhost:9180?sslmode=invalid";
+      DgraphClient.openConnection(conn);
+      fail("Should have thrown IllegalArgumentException for invalid sslmode");
+    } catch (IllegalArgumentException e) {
+      // Expected exception
+      assertTrue(e.getMessage().contains("Invalid sslmode"));
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getClass().getName() + ": " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that an appropriate exception is thrown when both apikey and bearertoken are provided.
+   */
+  @Test
+  public void testConflictingAuthMethodsException() {
+    try {
+      // Both apikey and bearertoken should throw IllegalArgumentException
+      String conn = "dgraph://localhost:9180?apikey=somekey&bearertoken=sometoken";
+      DgraphClient.openConnection(conn);
+      fail("Should have thrown IllegalArgumentException for conflicting auth methods");
+    } catch (IllegalArgumentException e) {
+      // Expected exception
+      assertTrue(e.getMessage().contains("apikey and bearertoken cannot both be provided"));
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getClass().getName() + ": " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that authorization header is properly set when using a bearertoken.
+   */
+  @Test
+  public void testBearerTokenAuth() {
+    try {
+      // This test is a bit tricky since we can't directly inspect the headers.
+      // We're mostly testing that the connection string parses correctly.
+      String conn = "dgraph://localhost:9180?bearertoken=test_token";
+      DgraphClient client = DgraphClient.openConnection(conn);
+      assertNotNull(client);
+      client.shutdown();
+    } catch (Exception e) {
+      fail("Failed to create client with bearertoken: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that authorization header is properly set when using an apikey.
+   */
+  @Test
+  public void testApiKeyAuth() {
+    try {
+      // This test is a bit tricky since we can't directly inspect the headers.
+      // We're mostly testing that the connection string parses correctly.
+      String conn = "dgraph://localhost:9180?apikey=test_api_key";
+      DgraphClient client = DgraphClient.openConnection(conn);
+      assertNotNull(client);
+      client.shutdown();
+    } catch (Exception e) {
+      fail("Failed to create client with apikey: " + e.getMessage());
+    }
+  }
+}

--- a/src/test/java/io/dgraph/DgraphConnTest.java
+++ b/src/test/java/io/dgraph/DgraphConnTest.java
@@ -33,12 +33,40 @@ public class DgraphConnTest {
       String query = "{ me(func: uid(1)) { uid }}";
       Response response = client.newTransaction().query(query);
       assertNotNull(response);
-      
       assertEquals(response.getJson().toStringUtf8(), EXPECTED_UID_JSON);
       
       client.shutdown();
     } catch (Exception e) {
       fail("Failed to connect with ACL: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests the Dgraph connection using the ClientOptions class.
+   * This test connects to a local Dgraph server with ACL credentials and plaintext.
+   */
+  @Test
+  public void testClientOptions() {
+    try {
+      DgraphClient client = DgraphClient.ClientOptions.forAddress("localhost", 9180)
+          .withACLCredentials("groot", "password")
+          .withPlaintext()
+          .build();
+      assertNotNull(client);
+
+      String query = "{ me(func: uid(1)) { uid }}";
+      Response response = client.newTransaction().query(query);
+      assertNotNull(response);
+      assertEquals(response.getJson().toStringUtf8(), EXPECTED_UID_JSON);
+
+      client.shutdown();
+    } catch (Exception e) {
+      Throwable cause = e;
+      while (cause != null) {
+        System.out.println("Cause: " + cause.getMessage());
+        cause = cause.getCause();
+      }
+      fail("Failed to connect with TLS: " + e.getMessage());
     }
   }
 

--- a/src/test/java/io/dgraph/DgraphConnTest.java
+++ b/src/test/java/io/dgraph/DgraphConnTest.java
@@ -20,14 +20,14 @@ public class DgraphConnTest {
   private static final String EXPECTED_UID_JSON = "{\"me\":[{\"uid\":\"0x1\"}]}";
 
   /**
-   * Tests the Dgraph connection using the openConnection method with ACL credentials.
+   * Tests the Dgraph connection using the open method with ACL credentials.
    * This test connects to a local Dgraph server with authentication.
    */
   @Test
-  public void testOpenConnectionWithACL() {
+  public void testOpenWithACL() {
     try {
       String conn = "dgraph://groot:password@localhost:9180";
-      DgraphClient client = DgraphClient.openConnection(conn);
+      DgraphClient client = DgraphClient.open(conn);
       assertNotNull(client);
       
       String query = "{ me(func: uid(1)) { uid }}";
@@ -52,7 +52,7 @@ public class DgraphConnTest {
     try {
       // Try to connect without providing credentials
       String conn = "dgraph://localhost:9180";
-      DgraphClient client = DgraphClient.openConnection(conn);
+      DgraphClient client = DgraphClient.open(conn);
       
       // Try a query to trigger the authentication error
       String query = "{ me(func: uid(1)) { uid }}";
@@ -90,7 +90,7 @@ public class DgraphConnTest {
     try {
       // Missing port in connection string should throw IllegalArgumentException
       String conn = "dgraph://localhost";
-      DgraphClient.openConnection(conn);
+      DgraphClient.open(conn);
       fail("Should have thrown IllegalArgumentException for missing port");
     } catch (IllegalArgumentException e) {
       // Expected exception
@@ -108,7 +108,7 @@ public class DgraphConnTest {
     try {
       // Invalid schema should throw IllegalArgumentException
       String conn = "http://localhost:9180";
-      DgraphClient.openConnection(conn);
+      DgraphClient.open(conn);
       fail("Should have thrown IllegalArgumentException for invalid schema");
     } catch (IllegalArgumentException e) {
       // Expected exception
@@ -126,7 +126,7 @@ public class DgraphConnTest {
     try {
       // Username without password should throw IllegalArgumentException
       String conn = "dgraph://groot@localhost:9180";
-      DgraphClient.openConnection(conn);
+      DgraphClient.open(conn);
       fail("Should have thrown IllegalArgumentException for missing password");
     } catch (IllegalArgumentException e) {
       // Expected exception
@@ -144,7 +144,7 @@ public class DgraphConnTest {
     try {
       // Invalid sslmode should throw IllegalArgumentException
       String conn = "dgraph://localhost:9180?sslmode=invalid";
-      DgraphClient.openConnection(conn);
+      DgraphClient.open(conn);
       fail("Should have thrown IllegalArgumentException for invalid sslmode");
     } catch (IllegalArgumentException e) {
       // Expected exception
@@ -162,7 +162,7 @@ public class DgraphConnTest {
     try {
       // Both apikey and bearertoken should throw IllegalArgumentException
       String conn = "dgraph://localhost:9180?apikey=somekey&bearertoken=sometoken";
-      DgraphClient.openConnection(conn);
+      DgraphClient.open(conn);
       fail("Should have thrown IllegalArgumentException for conflicting auth methods");
     } catch (IllegalArgumentException e) {
       // Expected exception
@@ -181,7 +181,7 @@ public class DgraphConnTest {
       // This test is a bit tricky since we can't directly inspect the headers.
       // We're mostly testing that the connection string parses correctly.
       String conn = "dgraph://localhost:9180?bearertoken=test_token";
-      DgraphClient client = DgraphClient.openConnection(conn);
+      DgraphClient client = DgraphClient.open(conn);
       assertNotNull(client);
       client.shutdown();
     } catch (Exception e) {
@@ -198,7 +198,7 @@ public class DgraphConnTest {
       // This test is a bit tricky since we can't directly inspect the headers.
       // We're mostly testing that the connection string parses correctly.
       String conn = "dgraph://localhost:9180?apikey=test_api_key";
-      DgraphClient client = DgraphClient.openConnection(conn);
+      DgraphClient client = DgraphClient.open(conn);
       assertNotNull(client);
       client.shutdown();
     } catch (Exception e) {


### PR DESCRIPTION
**Description**

This PR adds support for creating DgraphClient objects using connection strings. See the README in this PR for details.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [x] For public APIs, new features, etc., PR on
      [docs repo](https://github.com/hypermodeinc/docs) staged and linked here

