### PR TITLE
feat: add CD workflow to publish releases to Maven Central

### DIFF
--- a/.github/workflows/cd-dgraph4j.yml
+++ b/.github/workflows/cd-dgraph4j.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       releasetag:
-        description: "Release tag to build and publish"
+        description: Release tag to build and publish
         required: true
         type: string
 

--- a/.github/workflows/cd-dgraph4j.yml
+++ b/.github/workflows/cd-dgraph4j.yml
@@ -1,0 +1,55 @@
+name: cd-dgraph4j
+
+on:
+  workflow_dispatch:
+    inputs:
+      releasetag:
+        description: "Release tag to build and publish"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dgraph4j repo
+        uses: actions/checkout@v5
+        with:
+          ref: "${{ github.event.inputs.releasetag }}"
+          path: dgraph4j
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: microsoft
+          java-version-file: dgraph4j/.java-version
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Checkout Dgraph repo
+        uses: actions/checkout@v5
+        with:
+          path: dgraph
+          repository: dgraph-io/dgraph
+          ref: main
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: dgraph/go.mod
+      - name: Build dgraph binary
+        run: cd dgraph && make docker-image
+      - name: Spin up local dgraph cluster
+        run: cd dgraph4j && docker compose -f docker-compose.test.yml up -d
+      - name: Run tests
+        run: cd dgraph4j && ./gradlew build -i
+      - name: Tear down cluster
+        run: cd dgraph4j && docker compose -f docker-compose.test.yml down
+      - name: Publish to Maven Central
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+        run: cd dgraph4j && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -8,12 +8,12 @@ Dgraph owns the `io.dgraph` namespace on Maven Central. Releases are published a
 
 The following GitHub Actions secrets must be configured in the repository:
 
-| Secret               | Description                                                                 |
-| -------------------- | --------------------------------------------------------------------------- |
-| `OSSRH_USERNAME`     | Sonatype Central Portal user token username                                 |
-| `OSSRH_PASSWORD`     | Sonatype Central Portal user token password                                 |
-| `GPG_SIGNING_KEY`    | ASCII-armored GPG private key (`gpg --armor --export-secret-keys <key-id>`) |
-| `GPG_SIGNING_PASSWORD` | Passphrase for the GPG signing key                                        |
+| Secret                 | Description                                                                 |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `OSSRH_USERNAME`       | Sonatype Central Portal user token username                                 |
+| `OSSRH_PASSWORD`       | Sonatype Central Portal user token password                                 |
+| `GPG_SIGNING_KEY`      | ASCII-armored GPG private key (`gpg --armor --export-secret-keys <key-id>`) |
+| `GPG_SIGNING_PASSWORD` | Passphrase for the GPG signing key                                          |
 
 Portal user tokens can be generated at https://central.sonatype.com/usertoken.
 
@@ -60,4 +60,3 @@ Then run:
 - [Generating a Portal Token](https://central.sonatype.org/publish/generate-portal-token/)
 - [Publishing via the OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-gradle/)
 - [gradle-nexus/publish-plugin](https://github.com/gradle-nexus/publish-plugin)
-````

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,49 +1,63 @@
-## Publishing artefacts to Maven Central
+## Publishing Artifacts to Maven Central
 
-Dgraph owns the `io.dgraph` namespace on Maven Central. See [JIRA ticket][jira] for details. This
-document contains instructions to publish dgraph4j build artefacts to Maven central.
+Dgraph owns the `io.dgraph` namespace on Maven Central. Releases are published automatically via the
+`cd-dgraph4j` GitHub Actions workflow, which uploads to Maven Central through the
+[Sonatype Central Publisher Portal](https://central.sonatype.com).
 
-[jira]: https://issues.sonatype.org/browse/OSSRH-35895
+### Prerequisites
 
-### Before Deploying
+The following GitHub Actions secrets must be configured in the repository:
 
-- Get access to credentials for `dgraph` JIRA account on Maven Central.
-- Generate GPG credentials. Make sure you set a passphrase. You can use this
-  [guide](https://help.github.com/en/articles/generating-a-new-gpg-key).
-- Note down the short version of the Key ID: `gpg --list-keys --keyid-format short`.
-- Generate a secret key ring file if not present:
-  `gpg --export-secret-keys -o /path/to/.gnupg/secring.gpg`.
-- Publish the keys to the MIT server: `gpg --send-keys <key-id>` (Maven Central will check for keys
-  here).
-- Create `~/.gradle/gradle.properties` and populate it with all the credentials
-- Get the credentials from `profile` section after loggin into [Sonatype](https://oss.sonatype.org/)
+| Secret               | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `OSSRH_USERNAME`     | Sonatype Central Portal user token username                                 |
+| `OSSRH_PASSWORD`     | Sonatype Central Portal user token password                                 |
+| `GPG_SIGNING_KEY`    | ASCII-armored GPG private key (`gpg --armor --export-secret-keys <key-id>`) |
+| `GPG_SIGNING_PASSWORD` | Passphrase for the GPG signing key                                        |
 
-```sh
-signing.keyId=<…keyId…>
-signing.password=<…password…>
+Portal user tokens can be generated at https://central.sonatype.com/usertoken.
+
+The GPG public key must be published to a well-known keyserver (e.g. `keys.openpgp.org`,
+`keyserver.ubuntu.com`, or `pgp.mit.edu`) so that Maven Central can verify artifact signatures.
+
+### Release Process
+
+1. Create a `prepare-for-release-vXX.X.X` branch from `main`.
+2. Bump the `version` in `build.gradle`.
+3. Update the download version in README for both Maven and Gradle.
+4. Update the `Supported Versions` table in README.
+5. Update the `dgraph4j version` in the `grpc-netty` table in README.
+6. Update `CHANGELOG.md`.
+7. Open a PR, get it reviewed, and merge to `main`.
+8. Create a release tag on GitHub (e.g. `v25.0.0`) from the merged `main`.
+9. Go to **Actions** → **cd-dgraph4j** → **Run workflow** and enter the release tag.
+10. The workflow will build, test, sign, and publish the artifacts to Maven Central.
+11. Verify the release at https://central.sonatype.com/namespace/io.dgraph.
+
+### Local Publishing (for testing)
+
+Developers can still publish from a local machine by setting credentials in
+`~/.gradle/gradle.properties`:
+
+```properties
+ossrhUsername=<portal-token-username>
+ossrhPassword=<portal-token-password>
+
+signing.keyId=<gpg-key-id>
+signing.password=<gpg-passphrase>
 signing.secretKeyRingFile=</path/to/.gnupg/secring.gpg>
-
-ossrhUsername=<username>
-ossrhPassword=<token>
 ```
 
-### Deploying
+Then run:
 
-- Build and test the code that needs to be published.
-- Bump version by modifying the `version` variable in `build.gradle` file.
-- Update download version in README for both Maven and Gradle.
-- Update `Supported Versions` table in README.
-- Update `dgraph4j version` in `grpc-netty` table in README.
-- Update CHANGELOG.
-- Raise a PR for the above changes. Put the changelog in PR description and merge it.
-- Run `./gradlew publishMavenJavaPublicationToMavenRepository`.
-- Release the deployment by following the steps on the page _Releasing the Deployment_ (link in
-  references below).
-- Also cut a release tag on GitHub with the new version.
+```sh
+./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+```
 
 ### References
 
-- [Publishing a project on Maven Central](https://medium.com/@nmauti/publishing-a-project-on-maven-central-8106393db2c3)
-- [Deploying to OSSRH with Gradle - Introduction](http://central.sonatype.org/pages/gradle.html)
-- [StackOverflow thread on issues during signing artefacts](https://stackoverflow.com/questions/27936119/gradle-uploadarchives-task-unable-to-read-secret-key)
-- [Releasing the Deployment](http://central.sonatype.org/pages/releasing-the-deployment.html)
+- [Sonatype Central Publisher Portal](https://central.sonatype.com)
+- [Generating a Portal Token](https://central.sonatype.org/publish/generate-portal-token/)
+- [Publishing via the OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-gradle/)
+- [gradle-nexus/publish-plugin](https://github.com/gradle-nexus/publish-plugin)
+````

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id 'base'
     id 'maven-publish'
     id 'com.gradleup.shadow' version '8.3.6'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 apply plugin: 'java'
@@ -203,65 +204,61 @@ jacocoTestReport {
     }
 }
 
-if (project.hasProperty('ossrhUsername')) {
-    publishing {
-        java {
-            withSourcesJar()
-            withJavadocJar()
-        }
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
 
-        repositories {
-            maven {
-                def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'dgraph4j'
+            from components.java
+
+            pom {
+                name = 'dgraph4j'
+                description = 'Dgraph Java Client'
+                url = 'https://github.com/dgraph-io/dgraph4j'
+
+                licenses {
+                    license {
+                        name = 'Apache License 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
                 }
-
-                def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+                developers {
+                    developer {
+                        name = 'Istari Digital, Inc.'
+                        email = 'dgraph-admin@istaridigital.com'
+                    }
                 }
-
-                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            }
-        }
-
-        publications {
-            mavenJava(MavenPublication) {
-                artifactId = 'dgraph4j'
-                from components.java
-
-                pom {
-                    name = 'dgraph4j'
-                    description = 'Dgraph Java Client'
+                scm {
+                    connection = 'https://github.com/dgraph-io/dgraph4j.git'
                     url = 'https://github.com/dgraph-io/dgraph4j'
-
-                    licenses {
-                        license {
-                            name = 'Apache License 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        }
-                    }
-                    developers {
-                        developer {
-                            name = 'Istari Digital, Inc.'
-                            email = 'dgraph-admin@istaridigital.com'
-                        }
-                    }
-                    scm {
-                        connection = 'https://github.com/dgraph-io/dgraph4j.git'
-                        url = 'https://github.com/dgraph-io/dgraph4j'
-                    }
                 }
             }
         }
     }
+}
 
-    signing {
-        sign publishing.publications.mavenJava
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri('https://ossrh-staging-api.central.sonatype.com/service/local/'))
+            snapshotRepositoryUrl.set(uri('https://central.sonatype.com/repository/maven-snapshots/'))
+            username.set(System.getenv('OSSRH_USERNAME') ?: findProperty('ossrhUsername')?.toString())
+            password.set(System.getenv('OSSRH_PASSWORD') ?: findProperty('ossrhPassword')?.toString())
+        }
     }
+}
+
+signing {
+    def signingKey = System.getenv('GPG_SIGNING_KEY')
+    def signingPassword = System.getenv('GPG_SIGNING_PASSWORD')
+    if (signingKey) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+    }
+    sign publishing.publications.mavenJava
 }
 
 task version {


### PR DESCRIPTION
## Summary

Add a CD pipeline to automate publishing dgraph4j releases to Maven Central, replacing the previous manual process that targeted the now-EOL'd Sonatype OSSRH Nexus.

## Changes

- **`.github/workflows/cd-dgraph4j.yml`** — New `workflow_dispatch`-triggered workflow that builds, tests against a live Dgraph cluster, signs, and publishes to Maven Central
- **`build.gradle`** — Added `gradle-nexus/publish-plugin` v2.0.0 targeting the new Sonatype Central Portal via the OSSRH staging API compatibility layer; added in-memory GPG signing support for CI
- **`PUBLISHING.md`** — Rewritten to document the new automated release process

## How It Works

1. Prep a release (bump version, changelog, etc.) and merge to `main`
2. Create a release tag on GitHub
3. Go to **Actions → cd-dgraph4j → Run workflow** and enter the release tag
4. The workflow builds, tests, signs, and publishes automatically

## Credentials

Four GitHub Actions secrets are required (all now configured):
- `OSSRH_USERNAME` / `OSSRH_PASSWORD` — Sonatype Central Portal user token
- `GPG_SIGNING_KEY` / `GPG_SIGNING_PASSWORD` — ASCII-armored GPG private key and passphrase