### PR TITLE
fix: Move shaded jar into separate package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+**Changed**
+
+- The shaded jar is published as a separate package `io.dgraph:dgraph4j-shaded`, with a pom that
+  does not declare the bundled dependencies. It used to be published as a `shaded`-classified
+  artifact of `io.dgraph:dgraph4j`, which shares the pom of the main jar and therefore wrongly
+  declared all dependencies that the shaded jar already bundles.
+
 ## [25.0.0] - 2026-04-01
 
 **Added**

--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ or Gradle:
 compile 'io.dgraph:dgraph4j:25.0.0'
 ```
 
+There is also a shaded variant, which bundles all dependencies relocated into the
+`io.dgraph.dgraph4j.shaded` package, so that they cannot conflict with the versions used by your
+application. Its public API is identical, only the coordinates differ:
+
+```xml
+<dependency>
+  <groupId>io.dgraph</groupId>
+  <artifactId>dgraph4j-shaded</artifactId>
+  <version>25.0.0</version>
+</dependency>
+```
+
+or Gradle:
+
+```groovy
+implementation 'io.dgraph:dgraph4j-shaded:25.0.0'
+```
+
 ## Supported Versions
 
 Depending on the version of Dgraph that you are connecting to, you will have to use a different

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,11 @@ apply plugin: 'signing'
 group = 'io.dgraph'
 version = '25.0.0'
 
+def mainArtifactId = 'dgraph4j'
+def shadedArtifactId = 'dgraph4j-shaded'
+
 base {
-    archivesName = 'dgraph4j'
+    archivesName = mainArtifactId
 }
 
 // Upgrade to Java SE 11 to match updated protobuf-protoc version.
@@ -144,35 +147,30 @@ test {
     systemProperties['org.slf4j.simpleLogger.log.io.dgraph.DgraphIntegrationTest'] = 'DEBUG'
 }
 
-//create a single Jar with all dependencies
-task fatJar(type: Jar) {
+tasks.named('jar', Jar) {
     manifest {
         attributes 'Implementation-Title': 'Dgraph Client for Java',
                    'Implementation-Version': version
     }
-    base { archivesName = project.name + '-all' }
-    from { configurations.compile.collect { it.directory() ? it : zipTree(it) } }
-    with jar
 }
 
+// The shaded jar bundles all dependencies (relocated), so it cannot share the pom
+// of the main jar - that pom declares those very dependencies. It is therefore
+// published as its own package ('dgraph4j-shaded') with a dependency-free pom,
+// instead of as a classified artifact of the main package.
 tasks.named('shadowJar', ShadowJar) {
     enableRelocation = true
     relocationPrefix = 'io.dgraph.dgraph4j.shaded'
     relocate('google', 'io.dgraph.dgraph4j.shaded.google')
-    archiveClassifier.set('shaded')
+    archiveBaseName = shadedArtifactId
+    archiveClassifier = ''
     mergeServiceFiles()
 }
 
-task buildJar(type: Jar)
-
-task javadocJar(type: Jar) {
-    archiveClassifier = 'javadoc'
-    from javadoc
-}
-
-task sourceJar(type: Jar) {
-    archiveClassifier = 'sources'
-    from sourceSets.main.allJava
+// Keep the shaded jar out of the main package: the shadow plugin adds it to the
+// java component, which would publish it under the main coordinates.
+components.java.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
+    skip()
 }
 
 task updateProto(type: Exec) {
@@ -191,11 +189,9 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-artifacts {
-    archives jar
-    archives shadowJar
-    archives sourceJar
-    archives javadocJar
+// build both jars, as well as the sources and javadoc jars, on 'assemble'
+tasks.named('assemble') {
+    dependsOn tasks.named('shadowJar'), tasks.named('sourcesJar'), tasks.named('javadocJar')
 }
 
 jacocoTestReport {
@@ -209,34 +205,47 @@ java {
     withJavadocJar()
 }
 
+def configurePom = { pom, String pomName, String pomDescription ->
+    pom.name = pomName
+    pom.description = pomDescription
+    pom.url = 'https://github.com/dgraph-io/dgraph4j'
+
+    pom.licenses { licenses ->
+        licenses.license { license ->
+            license.name = 'Apache License 2.0'
+            license.url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+        }
+    }
+    pom.developers { developers ->
+        developers.developer { developer ->
+            developer.name = 'Istari Digital, Inc.'
+            developer.email = 'dgraph-admin@istaridigital.com'
+        }
+    }
+    pom.scm { scm ->
+        scm.connection = 'https://github.com/dgraph-io/dgraph4j.git'
+        scm.url = 'https://github.com/dgraph-io/dgraph4j'
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifactId = 'dgraph4j'
+            artifactId = mainArtifactId
             from components.java
 
-            pom {
-                name = 'dgraph4j'
-                description = 'Dgraph Java Client'
-                url = 'https://github.com/dgraph-io/dgraph4j'
+            configurePom(pom, mainArtifactId, 'Dgraph Java Client')
+        }
 
-                licenses {
-                    license {
-                        name = 'Apache License 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        name = 'Istari Digital, Inc.'
-                        email = 'dgraph-admin@istaridigital.com'
-                    }
-                }
-                scm {
-                    connection = 'https://github.com/dgraph-io/dgraph4j.git'
-                    url = 'https://github.com/dgraph-io/dgraph4j'
-                }
-            }
+        // The shaded jar carries its dependencies, hence this package has no
+        // dependencies declared in its pom.
+        mavenJavaShaded(MavenPublication) {
+            artifactId = shadedArtifactId
+            artifact tasks.named('shadowJar')
+            artifact tasks.named('sourcesJar')
+            artifact tasks.named('javadocJar')
+
+            configurePom(pom, shadedArtifactId, 'Dgraph Java Client with shaded dependencies')
         }
     }
 }
@@ -258,7 +267,7 @@ signing {
     if (signingKey) {
         useInMemoryPgpKeys(signingKey, signingPassword)
     }
-    sign publishing.publications.mavenJava
+    sign publishing.publications.mavenJava, publishing.publications.mavenJavaShaded
 }
 
 task version {


### PR DESCRIPTION
**Description**

In #239, I had added a shaded version of the jar. However, that shares the pom.xml with the main jar, hence all dependencies are still referenced. The shaded pom has to be published under its own package name.

This publishes the shaded jar under `dgraph4j-shaded`.

**Checklist**

- [X] Code compiles correctly and linting passes locally
- [X] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For public APIs, new features, etc., PR on
      [docs repo](https://github.com/dgraph-io/dgraph-docs) staged and linked here

Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph4j/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789070828&installation_model_id=8575&pr_number=300&repository=dgraph-io%2Fdgraph4j&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph4j%2Fpull%2F300&signature=f6e13de59b079f93d6d1c83196b44caecd8ace7a385d6d4db4e3f510fca32f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->